### PR TITLE
Lagt til CORS-støtte slik at POST kan utføres på localhost

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val prometheusVersion = "0.6.0"
-val ktorVersion = "1.2.4"
+val ktorVersion = "1.2.5"
 val junitVersion = "5.4.1"
 val kafkaVersion = "2.2.0"
 val confluentVersion = "5.2.0"
@@ -91,6 +91,8 @@ tasks {
     }
 
     register("runServer", JavaExec::class) {
+        environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
+
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
@@ -2,6 +2,6 @@ package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
 class ProduceBeskjedDto(val tekst: String, val link: String) {
     override fun toString(): String {
-        return "ProduceBeskjedDto{tekst='$tekst', lenke='$link'}"
+        return "ProduceBeskjedDto{tekst='$tekst', link='$link'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/Environment.kt
@@ -11,10 +11,11 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val dbReadOnlyUser: String = getEnvVar("DB_NAME", "test") + "-readonly",
                        val dbUrl: String = "jdbc:postgresql://$dbHost/$dbName",
                        val dbPassword: String = getEnvVar("DB_PASSWORD", "testpassword"),
-                       val dbMountPath: String = getEnvVar("DB_MOUNT_PATH", "notUsedOnLocalhost")
+                       val dbMountPath: String = getEnvVar("DB_MOUNT_PATH", "notUsedOnLocalhost"),
+                       val corsAllowedOrigins: String = getEnvVar("CORS_ALLOWED_ORIGINS")
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null): String {
-    return System.getenv(varName) ?: defaultValue
-    ?: throw IllegalArgumentException("Variable $varName cannot be empty")
+    val varValue = System.getenv(varName) ?: defaultValue
+    return varValue ?: throw IllegalArgumentException("Variable $varName cannot be empty")
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/bootstrap.kt
@@ -6,15 +6,17 @@ import io.ktor.application.Application
 import io.ktor.application.install
 import io.ktor.auth.Authentication
 import io.ktor.auth.authenticate
+import io.ktor.features.CORS
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
+import io.ktor.http.HttpHeaders
 import io.ktor.jackson.jackson
 import io.ktor.routing.routing
 import io.ktor.util.KtorExperimentalAPI
 import io.prometheus.client.hotspot.DefaultExports
+import no.nav.personbruker.dittnav.eventtestproducer.beskjed.beskjedApi
 import no.nav.personbruker.dittnav.eventtestproducer.common.healthApi
 import no.nav.personbruker.dittnav.eventtestproducer.done.doneApi
-import no.nav.personbruker.dittnav.eventtestproducer.beskjed.beskjedApi
 import no.nav.personbruker.dittnav.eventtestproducer.innboks.innboksApi
 import no.nav.personbruker.dittnav.eventtestproducer.oppgave.oppgaveApi
 import no.nav.security.token.support.ktor.tokenValidationSupport
@@ -23,6 +25,12 @@ import no.nav.security.token.support.ktor.tokenValidationSupport
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
     DefaultExports.initialize()
     install(DefaultHeaders)
+
+    install(CORS) {
+        host(appContext.environment.corsAllowedOrigins)
+        allowCredentials = true
+        header(HttpHeaders.ContentType)
+    }
 
     install(ContentNegotiation) {
         jackson {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/ProduceInnboksDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/ProduceInnboksDto.kt
@@ -2,6 +2,6 @@ package no.nav.personbruker.dittnav.eventtestproducer.innboks
 
 class ProduceInnboksDto(val tekst: String, val link: String) {
     override fun toString(): String {
-        return "ProduceInnboksDto{tekst='$tekst', lenke='$link'}"
+        return "ProduceInnboksDto{tekst='$tekst', link='$link'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
@@ -2,6 +2,6 @@ package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
 class ProduceOppgaveDto(val tekst: String, val link: String) {
     override fun toString(): String {
-        return "ProduceOppgaveDto{tekst='$tekst', lenke='$link'}"
+        return "ProduceOppgaveDto{tekst='$tekst', link='$link'}"
     }
 }


### PR DESCRIPTION
I det en nettleser skal utføre en POST mot en server, så vil det først sendes avgårde et preflight-kall som er av typen OPTIONS. For at Ktor skal slippe igjennom dette OPTIONS-kallet så må header-en ContentType være lagt til som en tillatt header.

PB-199. Forenkle lokal testing med sikkerhet aktivert