### PR TITLE
Hent token fra context

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ val postgresVersion = "42.2.5"
 val h2Version = "1.4.199"
 val jacksonVersion = "2.9.9"
 val kluentVersion = "1.52"
+val mockKVersion = "1.9.3"
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
@@ -67,6 +68,8 @@ dependencies {
     testImplementation("io.confluent:kafka-schema-registry:$confluentVersion")
     testImplementation("com.h2database:h2:$h2Version")
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
+    testCompile("io.ktor:ktor-client-mock:$ktorVersion")
+    testImplementation("io.mockk:mockk:$mockKVersion")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
 import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.common.createKeyForEvent
 import no.nav.personbruker.dittnav.eventtestproducer.config.Environment
 import no.nav.personbruker.dittnav.eventtestproducer.config.Kafka
@@ -16,18 +17,18 @@ object BeskjedProducer {
 
     private val log = LoggerFactory.getLogger(BeskjedProducer::class.java)
 
-    fun produceBeskjedEventForIdent(ident: String, dto: ProduceBeskjedDto) {
+    fun produceBeskjedEventForIdent(innloggetBruker: InnloggetBruker, dto: ProduceBeskjedDto) {
         KafkaProducer<Nokkel, Beskjed>(Kafka.producerProps(Environment())).use { producer ->
-            producer.send(ProducerRecord(beskjedTopicName, createKeyForEvent(), createBeskjedForIdent(ident, dto)))
+            producer.send(ProducerRecord(beskjedTopicName, createKeyForEvent(), createBeskjedForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et beskjeds-event for identen: $ident")
+        log.info("Har produsert et beskjeds-event for identen: ${innloggetBruker.getIdentFromToken()}")
     }
 
-    private fun createBeskjedForIdent(ident: String, dto: ProduceBeskjedDto): Beskjed {
+    private fun createBeskjedForIdent(innloggetBruker: InnloggetBruker, dto: ProduceBeskjedDto): Beskjed {
         val nowInMs = Instant.now().toEpochMilli()
         val weekFromNowInMs = Instant.now().plus(7, ChronoUnit.DAYS).toEpochMilli()
         val build = Beskjed.newBuilder()
-                .setFodselsnummer(ident)
+                .setFodselsnummer(innloggetBruker.getIdentFromToken())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
@@ -21,14 +21,14 @@ object BeskjedProducer {
         KafkaProducer<Nokkel, Beskjed>(Kafka.producerProps(Environment())).use { producer ->
             producer.send(ProducerRecord(beskjedTopicName, createKeyForEvent(), createBeskjedForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et beskjeds-event for identen: ${innloggetBruker.getIdentFromToken()}")
+        log.info("Har produsert et beskjeds-event for identen: ${innloggetBruker.getIdent()}")
     }
 
     private fun createBeskjedForIdent(innloggetBruker: InnloggetBruker, dto: ProduceBeskjedDto): Beskjed {
         val nowInMs = Instant.now().toEpochMilli()
         val weekFromNowInMs = Instant.now().plus(7, ChronoUnit.DAYS).toEpochMilli()
         val build = Beskjed.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdentFromToken())
+                .setFodselsnummer(innloggetBruker.getIdent())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
@@ -3,21 +3,21 @@ package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.config.userIdent
+import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
 
 fun Route.beskjedApi() {
 
     post("/produce/informasjon") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
-            BeskjedProducer.produceBeskjedEventForIdent(userIdent, beskjedDto)
-            "Et beskjed-event for identen: $userIdent har blitt lagt på kafka."
+            BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
+            "Et beskjed-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
         }
     }
 
     post("/produce/beskjed") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
-            BeskjedProducer.produceBeskjedEventForIdent(userIdent, beskjedDto)
-            "Et beskjed-event for identen: $userIdent har blitt lagt på kafka."
+            BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
+            "Et beskjed-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
@@ -10,14 +10,14 @@ fun Route.beskjedApi() {
     post("/produce/informasjon") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
             BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
-            "Et beskjed-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
+            "Et beskjed-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
         }
     }
 
     post("/produce/beskjed") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
             BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
-            "Et beskjed-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
+            "Et beskjed-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toBeskjed()
                     }
@@ -19,7 +19,7 @@ fun Connection.getAllBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toBeskjed()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
@@ -1,24 +1,25 @@
 package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
 import Beskjed
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import java.sql.Connection
 import java.sql.ResultSet
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-fun Connection.getAllBeskjedByFodselsnummer(fodselsnummer: String): List<Beskjed> =
+fun Connection.getAllBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toBeskjed()
                     }
                 }
 
-fun Connection.getBeskjedByFodselsnummer(fodselsnummer: String): List<Beskjed> =
+fun Connection.getBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toBeskjed()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
@@ -1,0 +1,37 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import io.ktor.application.ApplicationCall
+import io.ktor.application.call
+import io.ktor.auth.authentication
+import io.ktor.util.pipeline.PipelineContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+
+class InnloggetBruker(val token: JwtToken) {
+
+    fun getBearerToken(): String {
+        return "Bearer " + token.tokenAsString
+    }
+
+    fun getIdentFromToken(): String {
+        val ident = token.jwtTokenClaims.getStringClaim("sub")
+
+        if (isClaimElevenDigitsOrLess(ident)) {
+            return ident
+        }
+        return token.jwtTokenClaims.getStringClaim("pid")
+    }
+
+    private fun isClaimElevenDigitsOrLess(ident: String): Boolean {
+        val regex = """\d{1,11}""".toRegex()
+        return regex.matches(ident)
+    }
+}
+
+val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker get() =
+    call.authentication.principal<OIDCValidationContextPrincipal>()
+            ?.context
+            ?.firstValidToken
+            ?.map { token -> InnloggetBruker(token) }
+            ?.get()
+            ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
@@ -15,7 +15,7 @@ class InnloggetBruker(val token: JwtToken) {
         return "Bearer " + token.tokenAsString
     }
 
-    fun getIdentFromToken(): String {
+    fun getIdent(): String {
         var ident = token.jwtTokenClaims.getStringClaim("sub")
 
         if (isSubjectContainsOtherCharactersThanDigits(ident)) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/security.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/security.kt
@@ -1,30 +1,11 @@
 package no.nav.personbruker.dittnav.eventtestproducer.config
 
-import com.auth0.jwt.JWT
 import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
 import io.ktor.request.receive
 import io.ktor.response.respondText
 import io.ktor.util.pipeline.PipelineContext
-
-val PipelineContext<Unit, ApplicationCall>.userIdent get() = extractIdentFromToken()
-
-private fun PipelineContext<Unit, ApplicationCall>.extractIdentFromToken(): String {
-    var authToken = getTokenFromHeader()
-    if (authToken == null) {
-        authToken = getTokenFromCookie()
-    }
-    verifyThatATokenWasFound(authToken)
-    return extractSubject(authToken)
-}
-
-private fun verifyThatATokenWasFound(authToken: String?) {
-    if (authToken == null) {
-        throw Exception("Token ble ikke funnet. Dette skal ikke kunne skje.")
-    }
-}
 
 suspend inline fun PipelineContext<Unit, ApplicationCall>.respond(handler: () -> String) {
     val message = handler.invoke()
@@ -35,15 +16,4 @@ suspend inline fun <reified T : Any> PipelineContext<Unit, ApplicationCall>.resp
     val postParametersDto: T = call.receive()
     val message = handler.invoke(postParametersDto)
     call.respondText(text = message, contentType = ContentType.Text.Plain)
-}
-
-private fun PipelineContext<Unit, ApplicationCall>.getTokenFromHeader() =
-        call.request.headers[HttpHeaders.Authorization]?.replace("Bearer ", "")
-
-private fun PipelineContext<Unit, ApplicationCall>.getTokenFromCookie() =
-        call.request.cookies["selvbetjening-idtoken"]
-
-private fun extractSubject(authToken: String?): String {
-    val jwt = JWT.decode(authToken)
-    return jwt.getClaim("sub").asString() ?: "subject (ident) ikke funnet"
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneEventService.kt
@@ -3,25 +3,26 @@ package no.nav.personbruker.dittnav.eventtestproducer.done
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.Database
 import no.nav.personbruker.dittnav.eventtestproducer.beskjed.getBeskjedByFodselsnummer
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.innboks.getInnboksByFodselsnummer
 import no.nav.personbruker.dittnav.eventtestproducer.oppgave.getOppgaveByFodselsnummer
 
 class DoneEventService(
         private val database: Database) {
 
-    fun markAllBrukernotifikasjonerAsDone(fodselsnummer: String) = runBlocking {
-        val beskjed = database.dbQuery { getBeskjedByFodselsnummer(fodselsnummer) }
-        val oppgaver = database.dbQuery { getOppgaveByFodselsnummer(fodselsnummer) }
-        val innboks = database.dbQuery { getInnboksByFodselsnummer(fodselsnummer) }
+    fun markAllBrukernotifikasjonerAsDone(innloggetBruker: InnloggetBruker) = runBlocking {
+        val beskjed = database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }
+        val oppgaver = database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }
+        val innboks = database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }
 
         val alleBrukernotifikasjoner = beskjed + oppgaver + innboks
 
         alleBrukernotifikasjoner.forEach { brukernotifikasjon ->
-            DoneProducer.produceDoneEventForSpecifiedEvent(fodselsnummer, brukernotifikasjon)
+            DoneProducer.produceDoneEventForSpecifiedEvent(innloggetBruker, brukernotifikasjon)
         }
     }
 
-    fun markEventAsDone(fodselsnummer: String, eventId : String) {
-        DoneProducer.produceDoneEventForSuppliedEventId(fodselsnummer, eventId)
+    fun markEventAsDone(innloggetBruker: InnloggetBruker, eventId : String) {
+        DoneProducer.produceDoneEventForSuppliedEventId(innloggetBruker, eventId)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.done
 
 import no.nav.brukernotifikasjon.schemas.Done
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.common.createKeyForEvent
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.Brukernotifikasjon
 import no.nav.personbruker.dittnav.eventtestproducer.config.Environment
@@ -16,16 +17,16 @@ object DoneProducer {
 
     private val log = LoggerFactory.getLogger(DoneProducer::class.java)
 
-    fun produceDoneEventForSpecifiedEvent(ident: String, eventThatsDone: Brukernotifikasjon) {
-        val doneEvent = createDoneEvent(ident)
+    fun produceDoneEventForSpecifiedEvent(innloggetBruker: InnloggetBruker, eventThatsDone: Brukernotifikasjon) {
+        val doneEvent = createDoneEvent(innloggetBruker)
         produceDoneEvent(doneEvent, createKeyForEvent(eventThatsDone.eventId))
-        log.info("Har produsert et done-event for identen: $ident sitt event med eventId: ${eventThatsDone.eventId}")
+        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventId: ${eventThatsDone.eventId}")
     }
 
-    fun produceDoneEventForSuppliedEventId(ident: String, eventId: String) {
-        val doneEvent = createDoneEvent(ident)
+    fun produceDoneEventForSuppliedEventId(innloggetBruker: InnloggetBruker, eventId: String) {
+        val doneEvent = createDoneEvent(innloggetBruker)
         produceDoneEvent(doneEvent, createKeyForEvent(eventId))
-        log.info("Har produsert et done-event for identen: $ident sitt event med eventId: $eventId")
+        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventId: $eventId")
     }
 
     private fun produceDoneEvent(doneEvent : Done, key: Nokkel) {
@@ -34,10 +35,10 @@ object DoneProducer {
         }
     }
 
-    private fun createDoneEvent(ident: String): Done {
+    private fun createDoneEvent(innloggetBruker: InnloggetBruker): Done {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Done.newBuilder()
-                .setFodselsnummer(ident)
+                .setFodselsnummer(innloggetBruker.getIdentFromToken())
                 .setTidspunkt(nowInMs)
                 .setGrupperingsId("100$nowInMs")
         return build.build()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
@@ -20,13 +20,13 @@ object DoneProducer {
     fun produceDoneEventForSpecifiedEvent(innloggetBruker: InnloggetBruker, eventThatsDone: Brukernotifikasjon) {
         val doneEvent = createDoneEvent(innloggetBruker)
         produceDoneEvent(doneEvent, createKeyForEvent(eventThatsDone.eventId))
-        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventId: ${eventThatsDone.eventId}")
+        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdent()} sitt event med eventId: ${eventThatsDone.eventId}")
     }
 
     fun produceDoneEventForSuppliedEventId(innloggetBruker: InnloggetBruker, eventId: String) {
         val doneEvent = createDoneEvent(innloggetBruker)
         produceDoneEvent(doneEvent, createKeyForEvent(eventId))
-        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventId: $eventId")
+        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdent()} sitt event med eventId: $eventId")
     }
 
     private fun produceDoneEvent(doneEvent : Done, key: Nokkel) {
@@ -38,7 +38,7 @@ object DoneProducer {
     private fun createDoneEvent(innloggetBruker: InnloggetBruker): Done {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Done.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdentFromToken())
+                .setFodselsnummer(innloggetBruker.getIdent())
                 .setTidspunkt(nowInMs)
                 .setGrupperingsId("100$nowInMs")
         return build.build()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
@@ -11,14 +11,14 @@ fun Route.doneApi(doneEventService: DoneEventService) {
     post("/produce/done/all") {
         respond {
             doneEventService.markAllBrukernotifikasjonerAsDone(innloggetBruker)
-            "Done-eventer er produsert for alle identen: ${innloggetBruker.getIdentFromToken()} sine brukernotifikasjoner."
+            "Done-eventer er produsert for alle identen: ${innloggetBruker.getIdent()} sine brukernotifikasjoner."
         }
     }
 
     post("/produce/done") {
         respondForParameterType<ProduceDoneDto> { doneDto ->
             doneEventService.markEventAsDone(innloggetBruker, doneDto.eventId)
-            "Done-event er produsert for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventID: ${doneDto.eventId}."
+            "Done-event er produsert for identen: ${innloggetBruker.getIdent()} sitt event med eventID: ${doneDto.eventId}."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
@@ -4,21 +4,21 @@ import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respond
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.config.userIdent
+import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
 
 fun Route.doneApi(doneEventService: DoneEventService) {
 
     post("/produce/done/all") {
         respond {
-            doneEventService.markAllBrukernotifikasjonerAsDone(userIdent)
-            "Done-eventer er produsert for alle identen: $userIdent sine brukernotifikasjoner."
+            doneEventService.markAllBrukernotifikasjonerAsDone(innloggetBruker)
+            "Done-eventer er produsert for alle identen: ${innloggetBruker.getIdentFromToken()} sine brukernotifikasjoner."
         }
     }
 
     post("/produce/done") {
         respondForParameterType<ProduceDoneDto> { doneDto ->
-            doneEventService.markEventAsDone(userIdent, doneDto.eventId)
-            "Done-event er produsert for identen: $userIdent sitt event med eventID: ${doneDto.eventId}."
+            doneEventService.markEventAsDone(innloggetBruker, doneDto.eventId)
+            "Done-event er produsert for identen: ${innloggetBruker.getIdentFromToken()} sitt event med eventID: ${doneDto.eventId}."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
@@ -18,14 +18,14 @@ object InnboksProducer {
         KafkaProducer<Nokkel, Innboks>(Kafka.producerProps(Environment())).use { producer ->
             producer.send(ProducerRecord(Kafka.innboksTopicName, createKeyForEvent(), createInnboksForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et innboks-event for identen: ${innloggetBruker.getIdentFromToken()}")
+        log.info("Har produsert et innboks-event for identen: ${innloggetBruker.getIdent()}")
     }
 
     private fun createInnboksForIdent(innloggetBruker: InnloggetBruker, dto: ProduceInnboksDto): Innboks {
         val nowInMs = Instant.now().toEpochMilli()
 
         return Innboks.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdentFromToken())
+                .setFodselsnummer(innloggetBruker.getIdent())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
@@ -7,24 +7,25 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import no.nav.brukernotifikasjon.schemas.Innboks
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.common.createKeyForEvent
 import java.time.Instant
 
 object InnboksProducer {
     private val log = LoggerFactory.getLogger(InnboksProducer::class.java)
 
-    fun produceInnboksEventForIdent(ident: String, dto: ProduceInnboksDto) {
+    fun produceInnboksEventForIdent(innloggetBruker: InnloggetBruker, dto: ProduceInnboksDto) {
         KafkaProducer<Nokkel, Innboks>(Kafka.producerProps(Environment())).use { producer ->
-            producer.send(ProducerRecord(Kafka.innboksTopicName, createKeyForEvent(), createInnboksForIdent(ident, dto)))
+            producer.send(ProducerRecord(Kafka.innboksTopicName, createKeyForEvent(), createInnboksForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et innboks-event for identen: $ident")
+        log.info("Har produsert et innboks-event for identen: ${innloggetBruker.getIdentFromToken()}")
     }
 
-    private fun createInnboksForIdent(ident: String, dto: ProduceInnboksDto): Innboks {
+    private fun createInnboksForIdent(innloggetBruker: InnloggetBruker, dto: ProduceInnboksDto): Innboks {
         val nowInMs = Instant.now().toEpochMilli()
 
         return Innboks.newBuilder()
-                .setFodselsnummer(ident)
+                .setFodselsnummer(innloggetBruker.getIdentFromToken())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
@@ -9,7 +9,7 @@ fun Route.innboksApi() {
     post("/produce/innboks") {
         respondForParameterType<ProduceInnboksDto> { innboksDto ->
             InnboksProducer.produceInnboksEventForIdent(innloggetBruker, innboksDto)
-            "Et innboks-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
+            "Et innboks-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
@@ -3,13 +3,13 @@ package no.nav.personbruker.dittnav.eventtestproducer.innboks
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.config.userIdent
+import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
 
 fun Route.innboksApi() {
     post("/produce/innboks") {
         respondForParameterType<ProduceInnboksDto> { innboksDto ->
-            InnboksProducer.produceInnboksEventForIdent(userIdent, innboksDto)
-            "Et innboks-event for identen: $userIdent har blitt lagt på kafka."
+            InnboksProducer.produceInnboksEventForIdent(innloggetBruker, innboksDto)
+            "Et innboks-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toInnboks()
                     }
@@ -18,7 +18,7 @@ fun Connection.getAllInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toInnboks()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
@@ -1,23 +1,24 @@
 package no.nav.personbruker.dittnav.eventtestproducer.innboks
 
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import java.sql.Connection
 import java.sql.ResultSet
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-fun Connection.getAllInnboksByFodselsnummer(fodselsnummer: String): List<Innboks> =
+fun Connection.getAllInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toInnboks()
                     }
                 }
 
-fun Connection.getInnboksByFodselsnummer(fodselsnummer: String): List<Innboks> =
+fun Connection.getInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toInnboks()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
@@ -20,13 +20,13 @@ object OppgaveProducer {
         KafkaProducer<Nokkel, Oppgave>(Kafka.producerProps(Environment())).use { producer ->
             producer.send(ProducerRecord(oppgaveTopicName, createKeyForEvent(),createOppgaveForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et oppgace-event for identen: ${innloggetBruker.getIdentFromToken()}")
+        log.info("Har produsert et oppgace-event for identen: ${innloggetBruker.getIdent()}")
     }
 
     private fun createOppgaveForIdent(innloggetBruker: InnloggetBruker, dto: ProduceOppgaveDto): Oppgave {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Oppgave.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdentFromToken())
+                .setFodselsnummer(innloggetBruker.getIdent())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.Oppgave
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.common.createKeyForEvent
 import no.nav.personbruker.dittnav.eventtestproducer.config.Environment
 import no.nav.personbruker.dittnav.eventtestproducer.config.Kafka
@@ -15,17 +16,17 @@ object OppgaveProducer {
 
     private val log = LoggerFactory.getLogger(OppgaveProducer::class.java)
 
-    fun produceOppgaveEventForIdent(ident: String, dto: ProduceOppgaveDto) {
+    fun produceOppgaveEventForIdent(innloggetBruker: InnloggetBruker, dto: ProduceOppgaveDto) {
         KafkaProducer<Nokkel, Oppgave>(Kafka.producerProps(Environment())).use { producer ->
-            producer.send(ProducerRecord(oppgaveTopicName, createKeyForEvent(),createOppgaveForIdent(ident, dto)))
+            producer.send(ProducerRecord(oppgaveTopicName, createKeyForEvent(),createOppgaveForIdent(innloggetBruker, dto)))
         }
-        log.info("Har produsert et oppgace-event for identen: $ident")
+        log.info("Har produsert et oppgace-event for identen: ${innloggetBruker.getIdentFromToken()}")
     }
 
-    private fun createOppgaveForIdent(ident: String, dto: ProduceOppgaveDto): Oppgave {
+    private fun createOppgaveForIdent(innloggetBruker: InnloggetBruker, dto: ProduceOppgaveDto): Oppgave {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Oppgave.newBuilder()
-                .setFodselsnummer(ident)
+                .setFodselsnummer(innloggetBruker.getIdentFromToken())
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
@@ -3,14 +3,14 @@ package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.config.userIdent
+import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
 
 fun Route.oppgaveApi() {
 
     post("/produce/oppgave") {
         respondForParameterType<ProduceOppgaveDto> { oppgaveDto ->
-            OppgaveProducer.produceOppgaveEventForIdent(userIdent, oppgaveDto)
-            "Et oppgave-event for identen: $userIdent har blitt lagt på kafka."
+            OppgaveProducer.produceOppgaveEventForIdent(innloggetBruker, oppgaveDto)
+            "Et oppgave-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
@@ -10,7 +10,7 @@ fun Route.oppgaveApi() {
     post("/produce/oppgave") {
         respondForParameterType<ProduceOppgaveDto> { oppgaveDto ->
             OppgaveProducer.produceOppgaveEventForIdent(innloggetBruker, oppgaveDto)
-            "Et oppgave-event for identen: ${innloggetBruker.getIdentFromToken()} har blitt lagt på kafka."
+            "Et oppgave-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
@@ -1,23 +1,24 @@
 package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
 import java.sql.Connection
 import java.sql.ResultSet
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-fun Connection.getAllOppgaveByFodselsnummer(fodselsnummer: String): List<Oppgave> =
+fun Connection.getAllOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toOppgave()
                     }
                 }
 
-fun Connection.getOppgaveByFodselsnummer(fodselsnummer: String): List<Oppgave> =
+fun Connection.getOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, fodselsnummer)
+                    it.setString(1, innloggetBruker.getIdentFromToken())
                     it.executeQuery().list {
                         toOppgave()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toOppgave()
                     }
@@ -18,7 +18,7 @@ fun Connection.getAllOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdentFromToken())
+                    it.setString(1, innloggetBruker.getIdent())
                     it.executeQuery().list {
                         toOppgave()
                     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
@@ -1,6 +1,8 @@
 package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
+import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
 import org.junit.jupiter.api.Test
 import org.amshove.kluent.*
@@ -8,33 +10,54 @@ import org.amshove.kluent.*
 class BeskjedQueriesTest {
 
     private val database = H2Database()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Beskjed-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getAllBeskjedByFodselsnummer("12345") }.size `should be equal to` 3
+            database.dbQuery { getAllBeskjedByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
     }
 
     @Test
     fun `Finner kun aktive cachede Beskjed-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getBeskjedByFodselsnummer("12345") }.size `should be equal to` 2
+            database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
     }
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer for fodselsnummer ikke finnes`() {
+        val expectedIdent = "dummyIdent"
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getBeskjedByFodselsnummer("finnesikke") }.`should be empty`()
+            database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.`should be empty`()
         }
     }
 
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer hvis tom fodselsnummer`() {
+        val expectedIdent = ""
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getBeskjedByFodselsnummer("") }.`should be empty`()
+            database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.`should be empty`()
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
@@ -1,11 +1,11 @@
 package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
-import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
+import org.amshove.kluent.`should be empty`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
-import org.amshove.kluent.*
 
 class BeskjedQueriesTest {
 
@@ -14,10 +14,6 @@ class BeskjedQueriesTest {
 
     @Test
     fun `Finn alle cachede Beskjed-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getAllBeskjedByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
@@ -25,10 +21,6 @@ class BeskjedQueriesTest {
 
     @Test
     fun `Finner kun aktive cachede Beskjed-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
@@ -36,28 +28,20 @@ class BeskjedQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer for fodselsnummer ikke finnes`() {
-        val expectedIdent = "dummyIdent"
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
 
         runBlocking {
-            database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.`should be empty`()
+            database.dbQuery { getBeskjedByFodselsnummer(brukerUtenEventer) }.`should be empty`()
         }
     }
 
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer hvis tom fodselsnummer`() {
-        val expectedIdent = ""
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
 
         runBlocking {
-            database.dbQuery { getBeskjedByFodselsnummer(innloggetBruker) }.`should be empty`()
+            database.dbQuery { getBeskjedByFodselsnummer(brukerUtenFodselsnummer) }.`should be empty`()
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
@@ -1,0 +1,15 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.core.jwt.JwtToken
+
+object InnloggetBrukerObjectMother {
+
+    fun createInnloggetBruker(): InnloggetBruker {
+        val dummyJwtToken = mockk<JwtToken>()
+        val dummyTokenAsString = "dummyToken"
+        every { dummyJwtToken.tokenAsString} returns dummyTokenAsString
+        return InnloggetBruker(dummyJwtToken)
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
@@ -9,7 +9,17 @@ object InnloggetBrukerObjectMother {
     fun createInnloggetBruker(): InnloggetBruker {
         val dummyJwtToken = mockk<JwtToken>()
         val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString} returns dummyTokenAsString
+        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
+        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns "12345"
         return InnloggetBruker(dummyJwtToken)
     }
+
+    fun createInnloggetBrukerWithSubject(subject: String): InnloggetBruker {
+        val dummyJwtToken = mockk<JwtToken>()
+        val dummyTokenAsString = "dummyToken"
+        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
+        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns subject
+        return InnloggetBruker(dummyJwtToken)
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
@@ -14,7 +14,7 @@ internal class InnloggetBrukerTest {
         val expectedToken = "Bearer dummyToken"
 
         runBlocking {
-            val actualToken = innloggetBruker.getBearerToken()
+            val actualToken = innloggetBruker.generateAuthenticationHeader()
             actualToken `should be equal to` expectedToken
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
@@ -28,7 +28,7 @@ internal class InnloggetBrukerTest {
         coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
 
         runBlocking {
-            val actualIdent = innloggetBruker.getIdentFromToken()
+            val actualIdent = innloggetBruker.getIdent()
             actualIdent `should be equal to` expectedIdent
         }
     }
@@ -42,7 +42,7 @@ internal class InnloggetBrukerTest {
         coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
 
         runBlocking {
-            val actualIdent = innloggetBruker.getIdentFromToken()
+            val actualIdent = innloggetBruker.getIdent()
             actualIdent `should be equal to` expectedIdent
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
@@ -1,0 +1,49 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import io.mockk.coEvery
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class InnloggetBrukerTest {
+
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
+
+    @Test
+    fun `should return string with Bearer token`() {
+        val expectedToken = "Bearer dummyToken"
+
+        runBlocking {
+            val actualToken = innloggetBruker.getBearerToken()
+            actualToken `should be equal to` expectedToken
+        }
+    }
+
+    @Test
+    fun `should return string with ident from pid token claim`() {
+        val expectedIdent = "dummyIdent"
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
+        runBlocking {
+            val actualIdent = innloggetBruker.getIdentFromToken()
+            actualIdent `should be equal to` expectedIdent
+        }
+    }
+
+    @Test
+    fun `should return string with ident from sub token claim`() {
+        val expectedIdent = "123"
+        val pidClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns pidClaimThatIsNotAnIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
+        runBlocking {
+            val actualIdent = innloggetBruker.getIdentFromToken()
+            actualIdent `should be equal to` expectedIdent
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
@@ -1,6 +1,5 @@
 package no.nav.personbruker.dittnav.eventtestproducer.innboks
 
-import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
@@ -14,10 +13,6 @@ class InnboksQueriesTest {
 
     @Test
     fun `Finn alle cachede Innboks-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getAllInnboksByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
@@ -25,10 +20,6 @@ class InnboksQueriesTest {
 
     @Test
     fun `Finner kun aktive cachede Innboks-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
@@ -36,28 +27,19 @@ class InnboksQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer for fodselsnummer ikke finnes`() {
-        val expectedIdent = "dummyIdent"
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
 
         runBlocking {
-            database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.`should be empty`()
+            database.dbQuery { getInnboksByFodselsnummer(brukerUtenEventer) }.`should be empty`()
         }
     }
 
-
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer hvis tom fodselsnummer`() {
-        val expectedIdent = ""
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
 
         runBlocking {
-            database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.`should be empty`()
+            database.dbQuery { getInnboksByFodselsnummer(brukerUtenFodselsnummer) }.`should be empty`()
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
@@ -1,6 +1,8 @@
 package no.nav.personbruker.dittnav.eventtestproducer.innboks
 
+import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
 import org.amshove.kluent.`should be empty`
 import org.amshove.kluent.`should be equal to`
@@ -8,33 +10,54 @@ import org.junit.jupiter.api.Test
 
 class InnboksQueriesTest {
     private val database = H2Database()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Innboks-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getAllInnboksByFodselsnummer("12345") }.size `should be equal to` 3
+            database.dbQuery { getAllInnboksByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
     }
 
     @Test
     fun `Finner kun aktive cachede Innboks-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getInnboksByFodselsnummer("12345") }.size `should be equal to` 2
+            database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
     }
 
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer for fodselsnummer ikke finnes`() {
+        val expectedIdent = "dummyIdent"
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getInnboksByFodselsnummer("finnesikke") }.`should be empty`()
+            database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.`should be empty`()
         }
     }
 
 
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer hvis tom fodselsnummer`() {
+        val expectedIdent = ""
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getInnboksByFodselsnummer("") }.`should be empty`()
+            database.dbQuery { getInnboksByFodselsnummer(innloggetBruker) }.`should be empty`()
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
@@ -1,6 +1,8 @@
 package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
+import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
 import org.junit.jupiter.api.Test
 import org.amshove.kluent.*
@@ -8,32 +10,53 @@ import org.amshove.kluent.*
 class OppgaveQueriesTest {
 
     private val database = H2Database()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Oppgave-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getAllOppgaveByFodselsnummer("12345") }.size `should be equal to` 3
+            database.dbQuery { getAllOppgaveByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
     }
 
     @Test
     fun `Finn alle aktive cachede Oppgave-eventer for fodselsnummer`() {
+        val expectedIdent = "12345"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+
         runBlocking {
-            database.dbQuery { getOppgaveByFodselsnummer("12345") }.size `should be equal to` 2
+            database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
     }
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer for fodselsnummer ikke finnes`() {
+        val expectedIdent = "dummyIdent"
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getOppgaveByFodselsnummer("finnesikke") }.isEmpty()
+            database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.isEmpty()
         }
     }
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer hvis tom fodselsnummer`() {
+        val expectedIdent = ""
+        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
+        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+
         runBlocking {
-            database.dbQuery { getOppgaveByFodselsnummer("") }.isEmpty()
+            database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.isEmpty()
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
@@ -1,11 +1,10 @@
 package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
-import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.database.H2Database
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
-import org.amshove.kluent.*
 
 class OppgaveQueriesTest {
 
@@ -14,10 +13,6 @@ class OppgaveQueriesTest {
 
     @Test
     fun `Finn alle cachede Oppgave-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getAllOppgaveByFodselsnummer(innloggetBruker) }.size `should be equal to` 3
         }
@@ -25,10 +20,6 @@ class OppgaveQueriesTest {
 
     @Test
     fun `Finn alle aktive cachede Oppgave-eventer for fodselsnummer`() {
-        val expectedIdent = "12345"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
-
         runBlocking {
             database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.size `should be equal to` 2
         }
@@ -36,27 +27,19 @@ class OppgaveQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer for fodselsnummer ikke finnes`() {
-        val expectedIdent = "dummyIdent"
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
 
         runBlocking {
-            database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.isEmpty()
+            database.dbQuery { getOppgaveByFodselsnummer(bruker) }.isEmpty()
         }
     }
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer hvis tom fodselsnummer`() {
-        val expectedIdent = ""
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
-
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
 
         runBlocking {
-            database.dbQuery { getOppgaveByFodselsnummer(innloggetBruker) }.isEmpty()
+            database.dbQuery { getOppgaveByFodselsnummer(brukerUtenFodselsnummer) }.isEmpty()
         }
     }
 }


### PR DESCRIPTION
Vi henter token gjennom Nav.security.token.support sin context. Det vil si vi tar ikke stilling til om token-et kommer fra header eller cookie. Validering og uthenting av token skal security biblioteket ta seg av.

En liten refaktorering som gjør at vi wrapper token-et i InnloggetBruker objektet så vi kan ha all token logikk der.

feature/PB-334-henter-innloggetbruker-fra-context