### PR TITLE
Gjort oppretteksen av InnloggetBruker mer robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM navikt/java:13
 COPY build/libs/event-test-producer.jar /app/app.jar
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 \
+               -XX:+HeapDumpOnOutOfMemoryError \
+               -XX:HeapDumpPath=/oom-dump.hprof"
 ENV PORT=8080
 EXPOSE $PORT

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,9 @@ val h2Version = "1.4.199"
 val jacksonVersion = "2.9.9"
 val kluentVersion = "1.52"
 val mockKVersion = "1.9.3"
+val jjwtVersion = "0.11.0"
+val bcproVersion = "1.64"
+val navTokenValidator = "1.1.0"
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
@@ -43,7 +46,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compile("no.nav.security:token-validation-ktor:1.1.0")
+    compile("no.nav.security:token-validation-ktor:$navTokenValidator")
     compile("no.nav:vault-jdbc:$vaultJdbcVersion")
     compile("com.zaxxer:HikariCP:$hikariCPVersion")
     compile("org.postgresql:postgresql:$postgresVersion")
@@ -71,6 +74,10 @@ dependencies {
     testCompile("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.mockk:mockk:$mockKVersion")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testCompile("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+    testRuntime("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    testRuntime("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+    testRuntime("org.bouncycastle:bcprov-jdk15on:$bcproVersion")
 }
 
 application {
@@ -94,6 +101,7 @@ tasks {
 
     register("runServer", JavaExec::class) {
         environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
+        environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
 
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
@@ -24,20 +24,20 @@ object BeskjedProducer {
             val value = createBeskjedForIdent(innloggetBruker, dto)
             producer.send(ProducerRecord(beskjedTopicName, key, value))
         }
-        log.info("Har produsert et beskjeds-event for identen: ${innloggetBruker.getIdent()}")
+        log.info("Har produsert et beskjeds-event for for brukeren: $innloggetBruker")
     }
 
     private fun createBeskjedForIdent(innloggetBruker: InnloggetBruker, dto: ProduceBeskjedDto): Beskjed {
         val nowInMs = Instant.now().toEpochMilli()
         val weekFromNowInMs = Instant.now().plus(7, ChronoUnit.DAYS).toEpochMilli()
         val build = Beskjed.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdent())
+                .setFodselsnummer(innloggetBruker.ident)
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)
                 .setSynligFremTil(weekFromNowInMs)
-                .setSikkerhetsnivaa(innloggetBruker.getInnloggingsnivaa())
+                .setSikkerhetsnivaa(innloggetBruker.innloggingsnivaa)
         return build.build()
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
@@ -10,14 +10,14 @@ fun Route.beskjedApi() {
     post("/produce/informasjon") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
             BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
-            "Et beskjed-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
+            "Et beskjed-event for brukeren: $innloggetBruker har blitt lagt på kafka."
         }
     }
 
     post("/produce/beskjed") {
         respondForParameterType<ProduceBeskjedDto> { beskjedDto ->
             BeskjedProducer.produceBeskjedEventForIdent(innloggetBruker, beskjedDto)
-            "Et beskjed-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
+            "Et beskjed-event for brukeren: $innloggetBruker har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedApi.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
+import no.nav.personbruker.dittnav.eventtestproducer.config.innloggetBruker
 
 fun Route.beskjedApi() {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/beskjedQueries.kt
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toBeskjed()
                     }
@@ -19,7 +19,7 @@ fun Connection.getAllBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getBeskjedByFodselsnummer(innloggetBruker: InnloggetBruker): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toBeskjed()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/IdentityClaim.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/IdentityClaim.kt
@@ -1,0 +1,24 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+enum class IdentityClaim(val claimName : String) {
+
+    SUBJECT("sub"),
+    PID("pid");
+
+    companion object {
+        fun fromClaimName(claimName: String): IdentityClaim {
+            values().forEach { currentClaim ->
+                if (currentClaim.claimName == claimName.toLowerCase()) {
+                    return currentClaim
+                }
+            }
+            val msg = "Ugyldig claim name '$claimName', gyldige verdier er ${values().toSet()}"
+            throw IllegalArgumentException(msg)
+        }
+    }
+
+    override fun toString(): String {
+        return "IdentidyClaim(claimName='$claimName')"
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
@@ -4,46 +4,18 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.auth.authentication
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
 
-class InnloggetBruker(val token: JwtToken) {
+data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val token: String) {
 
-    private val allowOnlyDigits = """\d*""".toRegex()
-
-    fun generateAuthenticationHeader(): String {
-        return "Bearer " + token.tokenAsString
+    fun createAuthenticationHeader(): String {
+        return "Bearer $token"
     }
 
-    fun getIdent(): String {
-        var ident = token.jwtTokenClaims.getStringClaim("sub")
-
-        if (isSubjectContainsOtherCharactersThanDigits(ident)) {
-            ident = token.jwtTokenClaims.getStringClaim("pid")
-        }
-        return ident
+    override fun toString(): String {
+        return "InnloggetBruker(ident='***', innloggingsnivaa=$innloggingsnivaa, token='***')"
     }
 
-    fun getInnloggingsnivaa(): Int {
-        val innloggingsnivaaClaim = token.jwtTokenClaims.getStringClaim("acr")
-
-        return when (innloggingsnivaaClaim) {
-            "Level3" -> 3
-            "Level4" -> 4
-            else -> throw Exception("Innloggingsnivå ble ikke funnet. Dette skal ikke kunne skje.")
-        }
-    }
-
-    private fun isSubjectContainsOtherCharactersThanDigits(ident: String): Boolean {
-        return !allowOnlyDigits.matches(ident)
-    }
 }
 
 val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
-    get() =
-        call.authentication.principal<OIDCValidationContextPrincipal>()
-                ?.context
-                ?.firstValidToken
-                ?.map { token -> InnloggetBruker(token) }
-                ?.get()
-                ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
+    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBruker.kt
@@ -1,10 +1,5 @@
 package no.nav.personbruker.dittnav.eventtestproducer.common
 
-import io.ktor.application.ApplicationCall
-import io.ktor.application.call
-import io.ktor.auth.authentication
-import io.ktor.util.pipeline.PipelineContext
-
 data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val token: String) {
 
     fun createAuthenticationHeader(): String {
@@ -16,6 +11,3 @@ data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val tok
     }
 
 }
-
-val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
-    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerFactory.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerFactory.kt
@@ -1,0 +1,38 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import no.nav.personbruker.dittnav.eventtestproducer.config.getEnvVar
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+
+object InnloggetBrukerFactory {
+
+    private val IDENT_CLAIM: IdentityClaim
+    private val defaultClaim = IdentityClaim.SUBJECT
+    private val oidcIdentityClaimName = "OIDC_CLAIM_CONTAINING_THE_IDENTITY"
+
+    init {
+        val identityClaimFromEnvVariable = getEnvVar(oidcIdentityClaimName, defaultClaim.claimName)
+        IDENT_CLAIM = IdentityClaim.fromClaimName(identityClaimFromEnvVariable)
+    }
+
+    fun createNewInnloggetBruker(principal: OIDCValidationContextPrincipal?): InnloggetBruker {
+        val token = principal?.context?.firstValidToken?.get()
+                ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
+
+        val ident: String = token.jwtTokenClaims.getStringClaim(IDENT_CLAIM.claimName)
+        val innloggingsnivaa = extractInnloggingsnivaa(token)
+
+        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString)
+    }
+
+    private fun extractInnloggingsnivaa(token: JwtToken): Int {
+        val innloggingsnivaaClaim = token.jwtTokenClaims.getStringClaim("acr")
+
+        return when (innloggingsnivaaClaim) {
+            "Level3" -> 3
+            "Level4" -> 4
+            else -> throw Exception("Innloggingsnivå ble ikke funnet. Dette skal ikke kunne skje.")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/config/bootstrap.kt
@@ -3,9 +3,12 @@ package no.nav.personbruker.dittnav.eventtestproducer.config
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.ktor.application.Application
+import io.ktor.application.ApplicationCall
+import io.ktor.application.call
 import io.ktor.application.install
 import io.ktor.auth.Authentication
 import io.ktor.auth.authenticate
+import io.ktor.auth.authentication
 import io.ktor.features.CORS
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
@@ -13,8 +16,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.jackson.jackson
 import io.ktor.routing.routing
 import io.ktor.util.KtorExperimentalAPI
+import io.ktor.util.pipeline.PipelineContext
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.dittnav.eventtestproducer.beskjed.beskjedApi
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBruker
+import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerFactory
 import no.nav.personbruker.dittnav.eventtestproducer.common.healthApi
 import no.nav.personbruker.dittnav.eventtestproducer.done.doneApi
 import no.nav.personbruker.dittnav.eventtestproducer.innboks.innboksApi
@@ -56,3 +62,6 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     }
 
 }
+
+val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
+    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/DoneProducer.kt
@@ -22,7 +22,7 @@ object DoneProducer {
     fun produceDoneEventForSpecifiedEvent(innloggetBruker: InnloggetBruker, eventThatsDone: Brukernotifikasjon) {
         val doneEvent = createDoneEvent(innloggetBruker)
         produceDoneEvent(doneEvent, createKeyForEvent(eventThatsDone.eventId, env.systemUserName))
-        log.info("Har produsert et done-event for identen: ${innloggetBruker.getIdent()} sitt event med eventId: ${eventThatsDone.eventId}")
+        log.info("Har produsert et done-event for for brukeren: $innloggetBruker sitt event med eventId: ${eventThatsDone.eventId}")
     }
 
     private fun produceDoneEvent(doneEvent: Done, key: Nokkel) {
@@ -34,7 +34,7 @@ object DoneProducer {
     private fun createDoneEvent(innloggetBruker: InnloggetBruker): Done {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Done.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdent())
+                .setFodselsnummer(innloggetBruker.ident)
                 .setTidspunkt(nowInMs)
                 .setGrupperingsId("100$nowInMs")
         return build.build()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
@@ -2,7 +2,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.done
 
 import io.ktor.routing.Route
 import io.ktor.routing.post
-import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
+import no.nav.personbruker.dittnav.eventtestproducer.config.innloggetBruker
 import no.nav.personbruker.dittnav.eventtestproducer.config.respond
 
 fun Route.doneApi(doneEventService: DoneEventService) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/done/doneApi.kt
@@ -10,7 +10,7 @@ fun Route.doneApi(doneEventService: DoneEventService) {
     post("/produce/done/all") {
         respond {
             doneEventService.markAllBrukernotifikasjonerAsDone(innloggetBruker)
-            "Done-eventer er produsert for alle identen: ${innloggetBruker.getIdent()} sine brukernotifikasjoner."
+            "Done-eventer er produsert for alle for brukeren: $innloggetBruker sine brukernotifikasjoner."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
@@ -22,19 +22,19 @@ object InnboksProducer {
         KafkaProducer<Nokkel, Innboks>(Kafka.producerProps(Environment())).use { producer ->
             producer.send(ProducerRecord(Kafka.innboksTopicName, key, value))
         }
-        log.info("Har produsert et innboks-event for identen: ${innloggetBruker.getIdent()}")
+        log.info("Har produsert et innboks-event for for brukeren: $innloggetBruker")
     }
 
     private fun createInnboksForIdent(innloggetBruker: InnloggetBruker, dto: ProduceInnboksDto): Innboks {
         val nowInMs = Instant.now().toEpochMilli()
 
         return Innboks.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdent())
+                .setFodselsnummer(innloggetBruker.ident)
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)
-                .setSikkerhetsnivaa(innloggetBruker.getInnloggingsnivaa())
+                .setSikkerhetsnivaa(innloggetBruker.innloggingsnivaa)
                 .build()
     }
   }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.innboks
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
+import no.nav.personbruker.dittnav.eventtestproducer.config.innloggetBruker
 
 fun Route.innboksApi() {
     post("/produce/innboks") {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksApi.kt
@@ -9,7 +9,7 @@ fun Route.innboksApi() {
     post("/produce/innboks") {
         respondForParameterType<ProduceInnboksDto> { innboksDto ->
             InnboksProducer.produceInnboksEventForIdent(innloggetBruker, innboksDto)
-            "Et innboks-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
+            "Et innboks-event for for brukeren: $innloggetBruker har blitt lagt på kafka."
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/innboksQueries.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toInnboks()
                     }
@@ -18,7 +18,7 @@ fun Connection.getAllInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getInnboksByFodselsnummer(innloggetBruker: InnloggetBruker): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toInnboks()
                     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
@@ -23,18 +23,18 @@ object OppgaveProducer {
         KafkaProducer<Nokkel, Oppgave>(Kafka.producerProps(Environment())).use { producer ->
             producer.send(ProducerRecord(oppgaveTopicName, key, value))
         }
-        log.info("Har produsert et oppgace-event for identen: ${innloggetBruker.getIdent()}")
+        log.info("Har produsert et oppgace-event for for brukeren: $innloggetBruker")
     }
 
     private fun createOppgaveForIdent(innloggetBruker: InnloggetBruker, dto: ProduceOppgaveDto): Oppgave {
         val nowInMs = Instant.now().toEpochMilli()
         val build = Oppgave.newBuilder()
-                .setFodselsnummer(innloggetBruker.getIdent())
+                .setFodselsnummer(innloggetBruker.ident)
                 .setGrupperingsId("100$nowInMs")
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)
-                .setSikkerhetsnivaa(innloggetBruker.getInnloggingsnivaa())
+                .setSikkerhetsnivaa(innloggetBruker.innloggingsnivaa)
         return build.build()
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
@@ -10,7 +10,7 @@ fun Route.oppgaveApi() {
     post("/produce/oppgave") {
         respondForParameterType<ProduceOppgaveDto> { oppgaveDto ->
             OppgaveProducer.produceOppgaveEventForIdent(innloggetBruker, oppgaveDto)
-            "Et oppgave-event for identen: ${innloggetBruker.getIdent()} har blitt lagt på kafka."
+            "Et oppgave-event for for brukeren: $innloggetBruker har blitt lagt på kafka."
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveApi.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import no.nav.personbruker.dittnav.eventtestproducer.config.respondForParameterType
-import no.nav.personbruker.dittnav.eventtestproducer.common.innloggetBruker
+import no.nav.personbruker.dittnav.eventtestproducer.config.innloggetBruker
 
 fun Route.oppgaveApi() {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/oppgaveQueries.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 fun Connection.getAllOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ?""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toOppgave()
                     }
@@ -18,7 +18,7 @@ fun Connection.getAllOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): L
 fun Connection.getOppgaveByFodselsnummer(innloggetBruker: InnloggetBruker): List<Oppgave> =
         prepareStatement("""SELECT * FROM OPPGAVE WHERE fodselsnummer = ? AND aktiv = true""")
                 .use {
-                    it.setString(1, innloggetBruker.getIdent())
+                    it.setString(1, innloggetBruker.ident)
                     it.executeQuery().list {
                         toOppgave()
                     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedQueriesTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class BeskjedQueriesTest {
 
     private val database = H2Database()
-    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa4()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Beskjed-eventer for fodselsnummer`() {
@@ -28,7 +28,7 @@ class BeskjedQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer for fodselsnummer ikke finnes`() {
-        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
+        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBruker("456")
 
         runBlocking {
             database.dbQuery { getBeskjedByFodselsnummer(brukerUtenEventer) }.`should be empty`()
@@ -38,7 +38,7 @@ class BeskjedQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Beskjed-eventer hvis tom fodselsnummer`() {
-        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBruker("")
 
         runBlocking {
             database.dbQuery { getBeskjedByFodselsnummer(brukerUtenFodselsnummer) }.`should be empty`()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/IdentityClaimTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/IdentityClaimTest.kt
@@ -1,0 +1,25 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+
+internal class IdentityClaimTest {
+
+    @Test
+    fun `should convert valid strings to enum`() {
+        IdentityClaim.fromClaimName("pid") `should equal` IdentityClaim.PID
+        IdentityClaim.fromClaimName("PID") `should equal` IdentityClaim.PID
+        IdentityClaim.fromClaimName("sub") `should equal` IdentityClaim.SUBJECT
+        IdentityClaim.fromClaimName("SUB") `should equal` IdentityClaim.SUBJECT
+    }
+
+    @Test
+    fun `should throw exception if invalid value is received`() {
+        invoking {
+            IdentityClaim.fromClaimName("")
+        } `should throw` IllegalArgumentException::class
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerFactoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerFactoryTest.kt
@@ -1,0 +1,46 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import no.nav.personbruker.dittnav.eventtestproducer.common.OIDCValidationContextPrincipalObjectMother.createPrincipalForAzure
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldNotBeNullOrBlank
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class InnloggetBrukerFactoryTest {
+
+    @Test
+    fun `should throw exception if principal is missing`() {
+        invoking {
+            InnloggetBrukerFactory.createNewInnloggetBruker(null)
+        } `should throw` Exception::class
+    }
+
+    @Test
+    fun `should throw exception if the token context is empty`() {
+        val context = TokenValidationContext(emptyMap())
+        val principal = OIDCValidationContextPrincipal(context)
+        invoking {
+            InnloggetBrukerFactory.createNewInnloggetBruker(principal)
+        } `should throw` NoSuchElementException::class
+    }
+
+    @Test
+    fun `should extract identity from the claim with the name sub for tokens form Azure`() {
+        val expectedIdent = "000"
+        val expectedInnloggingsnivaa = 3
+
+        val principal = createPrincipalForAzure(expectedIdent, expectedInnloggingsnivaa)
+
+
+        val innloggetBruker = InnloggetBrukerFactory.createNewInnloggetBruker(principal)
+
+        innloggetBruker.ident `should be equal to` expectedIdent
+        innloggetBruker.innloggingsnivaa `should be equal to` expectedInnloggingsnivaa
+        innloggetBruker.token.shouldNotBeNullOrBlank()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerObjectMother.kt
@@ -1,43 +1,32 @@
 package no.nav.personbruker.dittnav.eventtestproducer.common
 
-import io.mockk.every
-import io.mockk.mockk
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
 import no.nav.security.token.support.core.jwt.JwtToken
+import java.security.Key
 
 object InnloggetBrukerObjectMother {
 
-    fun createInnloggetBrukerMedInnloggingsnivaa4(): InnloggetBruker {
-        val dummyJwtToken = mockk<JwtToken>()
-        val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns "12345"
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("acr") } returns "Level4"
-        return InnloggetBruker(dummyJwtToken)
+    private val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+
+    fun createInnloggetBruker(): InnloggetBruker {
+        val ident = "12345"
+        return createInnloggetBruker(ident)
     }
 
-    fun createInnloggetBrukerMedInnloggingsnivaa3(): InnloggetBruker {
-        val dummyJwtToken = mockk<JwtToken>()
-        val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns "12345"
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("acr") } returns "Level3"
-        return InnloggetBruker(dummyJwtToken)
+    fun createInnloggetBruker(ident: String): InnloggetBruker {
+        val innloggingsnivaa = 4
+        return createInnloggetBruker(ident, innloggingsnivaa)
     }
 
-    fun createInnloggetBrukerWithSubject(subject: String): InnloggetBruker {
-        val dummyJwtToken = mockk<JwtToken>()
-        val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns subject
-        return InnloggetBruker(dummyJwtToken)
-    }
-
-    fun createInnloggetBrukerUtenInnloggingsnivaa(): InnloggetBruker {
-        val dummyJwtToken = mockk<JwtToken>()
-        val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString } returns dummyTokenAsString
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("sub") } returns "12345"
-        return InnloggetBruker(dummyJwtToken)
+    fun createInnloggetBruker(ident: String, innloggingsnivaa : Int): InnloggetBruker {
+        val jws = Jwts.builder()
+                .setSubject(ident)
+                .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)
+                .signWith(key).compact()
+        val token = JwtToken(jws)
+        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString)
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/InnloggetBrukerTest.kt
@@ -1,73 +1,43 @@
 package no.nav.personbruker.dittnav.eventtestproducer.common
 
-import io.mockk.coEvery
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
-import org.amshove.kluent.`should throw`
-import org.amshove.kluent.invoking
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should not contain`
+import org.amshove.kluent.shouldNotBeNullOrBlank
 import org.junit.jupiter.api.Test
 
 internal class InnloggetBrukerTest {
 
-    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa4()
-
     @Test
-    fun `should return string with Bearer token`() {
-        val expectedToken = "Bearer dummyToken"
+    fun `should return expected values`() {
+        val expectedIdent = "12345"
+        val expectedInnloggingsnivaa = 4
 
-        runBlocking {
-            val actualToken = innloggetBruker.generateAuthenticationHeader()
-            actualToken `should be equal to` expectedToken
-        }
+        val innloggetbruker = InnloggetBrukerObjectMother.createInnloggetBruker(expectedIdent, expectedInnloggingsnivaa)
+
+        innloggetbruker.ident `should be equal to` expectedIdent
+        innloggetbruker.innloggingsnivaa `should be equal to` expectedInnloggingsnivaa
+        innloggetbruker.token.shouldNotBeNullOrBlank()
     }
 
     @Test
-    fun `should return string with ident from pid token claim`() {
-        val expectedIdent = "dummyIdent"
-        val subClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+    fun `should create authentication header`() {
+        val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns subClaimThatIsNotAnIdent
+        val generatedAuthHeader = innloggetBruker.createAuthenticationHeader()
 
-        runBlocking {
-            val actualIdent = innloggetBruker.getIdent()
-            actualIdent `should be equal to` expectedIdent
-        }
+        generatedAuthHeader `should be equal to` "Bearer ${innloggetBruker.token}"
     }
 
     @Test
-    fun `should return string with ident from sub token claim`() {
-        val expectedIdent = "123"
-        val pidClaimThatIsNotAnIdent = "dummyClaimThatIsNotAnIdent"
+    fun `should not include sensitive values in the output for the toString method`() {
+        val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid") } returns pidClaimThatIsNotAnIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub") } returns expectedIdent
+        val outputOfToString = innloggetBruker.toString()
 
-        runBlocking {
-            val actualIdent = innloggetBruker.getIdent()
-            actualIdent `should be equal to` expectedIdent
-        }
-    }
-
-    @Test
-    fun `should return innloggingsnivaa for nivaa 4`() {
-        val brukerPaaNivaa4 = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa4()
-        brukerPaaNivaa4.getInnloggingsnivaa() `should equal` 4
-    }
-
-    @Test
-    fun `should return innloggingsnivaa for nivaa 3`() {
-        val brukerPaaNivaa3 = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa3()
-        brukerPaaNivaa3.getInnloggingsnivaa() `should equal` 3
-    }
-
-    @Test
-    fun `should throw error if innloggingsnivaa not present`() {
-        val brukerUtenInnloggingsnivaa = InnloggetBrukerObjectMother.createInnloggetBrukerUtenInnloggingsnivaa()
-        invoking {
-            brukerUtenInnloggingsnivaa.getInnloggingsnivaa()
-        } `should throw` Exception::class
+        outputOfToString `should contain`(innloggetBruker.innloggingsnivaa.toString())
+        outputOfToString `should not contain`(innloggetBruker.ident)
+        outputOfToString `should not contain`(innloggetBruker.token)
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/OIDCValidationContextPrincipalObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/OIDCValidationContextPrincipalObjectMother.kt
@@ -1,0 +1,57 @@
+package no.nav.personbruker.dittnav.eventtestproducer.common
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import java.security.Key
+import java.time.Instant
+import java.util.*
+
+object OIDCValidationContextPrincipalObjectMother {
+
+    fun createPrincipalForAzure(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
+        val expiredJws = Jwts.builder()
+                .setSubject(ident)
+                .setExpiration(inTwoMinutes)
+                .addClaims(
+                        mutableMapOf(
+                                Pair("acr", "Level$innloggingsnivaa"
+                                )) as Map<String, Any>?)
+                .signWith(key).compact()
+
+        val token = JwtToken(expiredJws)
+
+        val issuerShortNameValidatedTokenMap = mutableMapOf<String, JwtToken>()
+        val issuer = "keyForIssuer"
+        issuerShortNameValidatedTokenMap[issuer] = token
+        val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
+        return OIDCValidationContextPrincipal(context)
+    }
+
+    fun createPrincipalForIdPorten(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
+        val expiredJws = Jwts.builder()
+                .setExpiration(inTwoMinutes)
+                .addClaims(
+                        mutableMapOf(
+                                Pair("acr", "Level$innloggingsnivaa"),
+                                Pair("pid", ident)
+                        ) as Map<String, Any>?)
+                .signWith(key).compact()
+
+        val token = JwtToken(expiredJws)
+
+        val issuerShortNameValidatedTokenMap = mutableMapOf<String, JwtToken>()
+        val issuer = "keyForIssuer"
+        issuerShortNameValidatedTokenMap[issuer] = token
+        val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
+        return OIDCValidationContextPrincipal(context)
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksQueriesTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 class InnboksQueriesTest {
     private val database = H2Database()
-    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa4()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Innboks-eventer for fodselsnummer`() {
@@ -27,7 +27,7 @@ class InnboksQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer for fodselsnummer ikke finnes`() {
-        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
+        val brukerUtenEventer = InnloggetBrukerObjectMother.createInnloggetBruker("456")
 
         runBlocking {
             database.dbQuery { getInnboksByFodselsnummer(brukerUtenEventer) }.`should be empty`()
@@ -36,7 +36,7 @@ class InnboksQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Innboks-eventer hvis tom fodselsnummer`() {
-        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBruker("")
 
         runBlocking {
             database.dbQuery { getInnboksByFodselsnummer(brukerUtenFodselsnummer) }.`should be empty`()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveQueriesTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class OppgaveQueriesTest {
 
     private val database = H2Database()
-    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBrukerMedInnloggingsnivaa4()
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `Finn alle cachede Oppgave-eventer for fodselsnummer`() {
@@ -27,7 +27,7 @@ class OppgaveQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer for fodselsnummer ikke finnes`() {
-        val bruker = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("456")
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBruker("456")
 
         runBlocking {
             database.dbQuery { getOppgaveByFodselsnummer(bruker) }.isEmpty()
@@ -36,7 +36,7 @@ class OppgaveQueriesTest {
 
     @Test
     fun `Returnerer tom liste hvis Oppgave-eventer hvis tom fodselsnummer`() {
-        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBrukerWithSubject("")
+        val brukerUtenFodselsnummer = InnloggetBrukerObjectMother.createInnloggetBruker("")
 
         runBlocking {
             database.dbQuery { getOppgaveByFodselsnummer(brukerUtenFodselsnummer) }.isEmpty()


### PR DESCRIPTION
* For alle request-er hvor en bruker er autentisert skal det opprettes en instans av InnloggetBruker, denne opprettelsen har nå blitt gjort mer robust og det er lagt til tester.
* Innholdet i InnloggetBruker er ikke lengre mock-et, men bruker dummy-instanser av gyldige kortlevde token.
* InnloggetBruker sin toString-metode returnerer ikke sensitiv informasjon.