### PR TITLE
Feature/statusoppdatering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 HELP.md
 .gradle
-/build/
+build
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.09.21-16.19-0e04a3fcc2e7"
+val dittNavDependenciesVersion = "2020.10.05-09.03-c152824aa61a"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: personbruker
 spec:
+  envFrom:
+    - configmap: loginservice-idporten
   image: {{version}}
   port: 8080
   liveness:

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
@@ -32,7 +32,7 @@ class BeskjedProducer(private val beskjedKafkaProducer: KafkaProducerWrapper<Bes
         val weekFromNowInMs = Instant.now().plus(7, ChronoUnit.DAYS).toEpochMilli()
         val build = Beskjed.newBuilder()
                 .setFodselsnummer(innloggetBruker.ident)
-                .setGrupperingsId("100$nowInMs")
+                .setGrupperingsId(dto.grupperingsid)
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
@@ -4,6 +4,6 @@ class ProduceBeskjedDto(val tekst: String,
                         val link: String,
                         val grupperingsid: String) {
     override fun toString(): String {
-        return "ProduceBeskjedDto{tekst='$tekst', link='$link', grupperingsid=$grupperingsid}"
+        return "ProduceBeskjedDto{tekst='$tekst', link='$link', grupperingsid='$grupperingsid'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
-class ProduceBeskjedDto(val tekst: String, val link: String) {
+class ProduceBeskjedDto(val tekst: String,
+                        val link: String,
+                        val grupperingsid: String) {
     override fun toString(): String {
-        return "ProduceBeskjedDto{tekst='$tekst', link='$link'}"
+        return "ProduceBeskjedDto{tekst='$tekst', link='$link', grupperingsid=$grupperingsid}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducer.kt
@@ -31,7 +31,7 @@ class InnboksProducer(private val innboksKafkaProducer: KafkaProducerWrapper<Inn
 
         return Innboks.newBuilder()
                 .setFodselsnummer(innloggetBruker.ident)
-                .setGrupperingsId("100$nowInMs")
+                .setGrupperingsId(dto.grupperingsid)
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/ProduceInnboksDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/ProduceInnboksDto.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.eventtestproducer.innboks
 
-class ProduceInnboksDto(val tekst: String, val link: String) {
+class ProduceInnboksDto(val tekst: String,
+                        val link: String,
+                        val grupperingsid: String) {
     override fun toString(): String {
-        return "ProduceInnboksDto{tekst='$tekst', link='$link'}"
+        return "ProduceInnboksDto{tekst='$tekst', link='$link', grupperingsid='$grupperingsid'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducer.kt
@@ -30,7 +30,7 @@ class OppgaveProducer(private val oppgaveKafkaProducer: KafkaProducerWrapper<Opp
         val nowInMs = Instant.now().toEpochMilli()
         val build = Oppgave.newBuilder()
                 .setFodselsnummer(innloggetBruker.ident)
-                .setGrupperingsId("100$nowInMs")
+                .setGrupperingsId(dto.grupperingsid)
                 .setLink(dto.link)
                 .setTekst(dto.tekst)
                 .setTidspunkt(nowInMs)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.eventtestproducer.oppgave
 
-class ProduceOppgaveDto(val tekst: String, val link: String) {
+class ProduceOppgaveDto(val tekst: String,
+                        val link: String,
+                        val grupperingsid: String) {
     override fun toString(): String {
-        return "ProduceOppgaveDto{tekst='$tekst', link='$link'}"
+        return "ProduceOppgaveDto{tekst='$tekst', link='$link', grupperingsid=$grupperingsid}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/ProduceOppgaveDto.kt
@@ -4,6 +4,6 @@ class ProduceOppgaveDto(val tekst: String,
                         val link: String,
                         val grupperingsid: String) {
     override fun toString(): String {
-        return "ProduceOppgaveDto{tekst='$tekst', link='$link', grupperingsid=$grupperingsid}"
+        return "ProduceOppgaveDto{tekst='$tekst', link='$link', grupperingsid='$grupperingsid'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/ProduceStatusoppdateringDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/ProduceStatusoppdateringDto.kt
@@ -7,6 +7,6 @@ class ProduceStatusoppdateringDto (val link: String,
                                    val grupperingsid: String)
 {
     override fun toString(): String {
-        return "ProduceStatusoppdateringDto{link='$link', statusGlobal='$statusGlobal', statusIntern='$statusIntern', sakstema='$sakstema', grupperingsid=$grupperingsid}"
+        return "ProduceStatusoppdateringDto{link='$link', statusGlobal='$statusGlobal', statusIntern='$statusIntern', sakstema='$sakstema', grupperingsid='$grupperingsid'}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/ProduceStatusoppdateringDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/ProduceStatusoppdateringDto.kt
@@ -3,9 +3,10 @@ package no.nav.personbruker.dittnav.eventtestproducer.statusoppdatering
 class ProduceStatusoppdateringDto (val link: String,
                                    val statusGlobal: String,
                                    val statusIntern: String,
-                                   val sakstema: String)
+                                   val sakstema: String,
+                                   val grupperingsid: String)
 {
     override fun toString(): String {
-        return "ProduceStatusoppdateringDto{link='$link', statusGlobal='$statusGlobal', statusIntern='$statusIntern', sakstema='$sakstema'}"
+        return "ProduceStatusoppdateringDto{link='$link', statusGlobal='$statusGlobal', statusIntern='$statusIntern', sakstema='$sakstema', grupperingsid=$grupperingsid}"
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/StatusoppdateringProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/StatusoppdateringProducer.kt
@@ -30,7 +30,7 @@ class StatusoppdateringProducer(private val statusoppdateringKafkaProducer: Kafk
         val nowInMs = Instant.now().toEpochMilli()
         val build = Statusoppdatering.newBuilder()
                 .setFodselsnummer(innloggetBruker.ident)
-                .setGrupperingsId("100$nowInMs")
+                .setGrupperingsId(dto.grupperingsid)
                 .setLink(dto.link)
                 .setTidspunkt(nowInMs)
                 .setSikkerhetsnivaa(innloggetBruker.innloggingsnivaa)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/ytelsestesting/TestDataService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/ytelsestesting/TestDataService.kt
@@ -33,7 +33,7 @@ class TestDataService(
         val start = Instant.now()
         for (i in 1..antallEventer) {
             val key = createKeyForEvent("b-$i", dummySystembruker)
-            val dto = ProduceBeskjedDto("Beskjedtekst $i", "https://beskjed-$i")
+            val dto = ProduceBeskjedDto("Beskjedtekst $i", "https://beskjed-$i", "grupperingsid-$i")
             val beskjedEvent = beskjedProducer.createBeskjedForIdent(bruker, dto)
             val doneEvent = doneProducer.createDoneEvent(bruker)
             beskjedProducer.sendEventToKafka(key, beskjedEvent)
@@ -51,7 +51,7 @@ class TestDataService(
         val start = Instant.now()
         for (i in 1..antallEventer) {
             val key = createKeyForEvent("o-$i", dummySystembruker)
-            val dto = ProduceOppgaveDto("Oppgavetekst $i", "https://oppgave-$i")
+            val dto = ProduceOppgaveDto("Oppgavetekst $i", "https://oppgave-$i", "grupperingsid-$i")
             val oppgaveEvent = oppgaveProducer.createOppgaveForIdent(bruker, dto)
             val doneEvent = doneProducer.createDoneEvent(bruker)
             oppgaveProducer.sendEventToKafka(key, oppgaveEvent)
@@ -87,7 +87,7 @@ class TestDataService(
         val start = Instant.now()
         for (i in 1..antallEventer) {
             val key = createKeyForEvent("s-$i", dummySystembruker)
-            val dto = ProduceStatusoppdateringDto("dummyLink_$i", "SENDT", "dummyStatusIntern_$i", "dummySakstema_$i")
+            val dto = ProduceStatusoppdateringDto("dummyLink_$i", "SENDT", "dummyStatusIntern_$i", "dummySakstema_$i", "grupperingsid-$i")
             val statusoppdateringEvent = statusoppdateringProducer.createStatusoppdateringForIdent(bruker, dto)
             val doneEvent = doneProducer.createDoneEvent(bruker)
             statusoppdateringProducer.sendEventToKafka(key, statusoppdateringEvent)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/ytelsestesting/TestDataService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/ytelsestesting/TestDataService.kt
@@ -69,7 +69,7 @@ class TestDataService(
         val start = Instant.now()
         for (i in 1..antallEventer) {
             val key = createKeyForEvent("i-$i", dummySystembruker)
-            val dto = ProduceInnboksDto("Innbokstekst $i", "https://innboks-$i")
+            val dto = ProduceInnboksDto("Innbokstekst $i", "https://innboks-$i", "grupperingsid-$i")
             val innboksEvent = innboksProducer.createInnboksForIdent(bruker, dto)
             val doneEvent = doneProducer.createDoneEvent(bruker)
             innboksProducer.sendEventToKafka(key, innboksEvent)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,8 +14,8 @@ no.nav.security.jwt {
   issuers = [
     {
       issuer_name = ${?OIDC_ISSUER}
-      discoveryurl = ${?OIDC_DISCOVERY_URL}
-      accepted_audience = ${?OIDC_ACCEPTED_AUDIENCE}
+      discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
+      accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
       cookie_name = selvbetjening-idtoken
     }
   ]

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducerTest.kt
@@ -15,6 +15,7 @@ class BeskjedProducerTest {
     private val systembruker = "x-dittNAV"
     private val link = "dummyLink"
     private val tekst = "dummyTekst"
+    private val grupperingsid = "dummyGrupperingsid"
     private val innlogetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(fodselsnummer)
     private val beskjedKafkaProducer = mockk<KafkaProducerWrapper<Beskjed>>()
     private val beskjedProducer = BeskjedProducer(beskjedKafkaProducer, systembruker)
@@ -22,10 +23,11 @@ class BeskjedProducerTest {
     @Test
     fun `should create beskjed-event`() {
         runBlocking {
-            val beskjedDto = ProduceBeskjedDto(tekst, link)
+            val beskjedDto = ProduceBeskjedDto(tekst, link, grupperingsid)
             val beskjedKafkaEvent = beskjedProducer.createBeskjedForIdent(innlogetBruker, beskjedDto)
             beskjedKafkaEvent.getLink() `should be equal to` link
             beskjedKafkaEvent.getTekst() `should be equal to` tekst
+            beskjedKafkaEvent.getGrupperingsId() `should be equal to` grupperingsid
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/innboks/InnboksProducerTest.kt
@@ -15,6 +15,7 @@ class InnboksProducerTest {
     private val systembruker = "x-dittNAV"
     private val link = "dummyLink"
     private val tekst = "dummyTekst"
+    private val grupperingsid = "dummyGrupperingsid"
     private val innlogetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(fodselsnummer)
     private val innboksKafkaProducer = mockk<KafkaProducerWrapper<Innboks>>()
     private val innboksProducer = InnboksProducer(innboksKafkaProducer, systembruker)
@@ -22,10 +23,11 @@ class InnboksProducerTest {
     @Test
     fun `should create innboks-event`() {
         runBlocking {
-            val innboksDto = ProduceInnboksDto(tekst, link)
+            val innboksDto = ProduceInnboksDto(tekst, link, grupperingsid)
             val innboksKafkaEvent = innboksProducer.createInnboksForIdent(innlogetBruker, innboksDto)
             innboksKafkaEvent.getLink() `should be equal to` link
             innboksKafkaEvent.getTekst() `should be equal to` tekst
+            innboksKafkaEvent.getGrupperingsId() `should be equal to` grupperingsid
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/oppgave/OppgaveProducerTest.kt
@@ -15,6 +15,7 @@ class OppgaveProducerTest {
     private val systembruker = "x-dittNAV"
     private val link = "dummyLink"
     private val tekst = "dummyTekst"
+    private val grupperingsid = "dummyGrupperingsid"
     private val innlogetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(fodselsnummer)
     private val oppgaveKafkaProducer = mockk<KafkaProducerWrapper<Oppgave>>()
     private val oppgaveProducer = OppgaveProducer(oppgaveKafkaProducer, systembruker)
@@ -22,10 +23,11 @@ class OppgaveProducerTest {
     @Test
     fun `should create oppgave-event`() {
         runBlocking {
-            val oppgaveDto = ProduceOppgaveDto(tekst, link)
+            val oppgaveDto = ProduceOppgaveDto(tekst, link, grupperingsid)
             val oppgaveKafkaEvent = oppgaveProducer.createOppgaveForIdent(innlogetBruker, oppgaveDto)
             oppgaveKafkaEvent.getLink() `should be equal to` link
             oppgaveKafkaEvent.getTekst() `should be equal to` tekst
+            oppgaveKafkaEvent.getGrupperingsId() `should be equal to` grupperingsid
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/StatusoppdateringProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/statusoppdatering/StatusoppdateringProducerTest.kt
@@ -17,6 +17,7 @@ class StatusoppdateringProducerTest {
     private val statusInternal = "dummyStatusInternal"
     private val sakstema = "dummySakstema"
     private val link = "dummyLink"
+    private val grupperingsid = "dummyGrupperingsid"
     private val innlogetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(fodselsnummer)
     private val statusoppdateringKafkaProducer = mockk<KafkaProducerWrapper<Statusoppdatering>>()
     private val statusoppdateringProducer = StatusoppdateringProducer(statusoppdateringKafkaProducer, systembruker)
@@ -24,13 +25,14 @@ class StatusoppdateringProducerTest {
     @Test
     fun `should create statusoppdatering-event`() {
         runBlocking {
-            val statusoppdateringDto = ProduceStatusoppdateringDto(link, statusGlobal, statusInternal, sakstema)
+            val statusoppdateringDto = ProduceStatusoppdateringDto(link, statusGlobal, statusInternal, sakstema, grupperingsid)
             val statusoppdateringKafkaEvent = statusoppdateringProducer.createStatusoppdateringForIdent(innlogetBruker, statusoppdateringDto)
             statusoppdateringKafkaEvent.getLink() `should be equal to` link
             statusoppdateringKafkaEvent.getStatusGlobal() `should be equal to` statusGlobal
             statusoppdateringKafkaEvent.getStatusIntern() `should be equal to` statusInternal
             statusoppdateringKafkaEvent.getSakstema() `should be equal to` sakstema
             statusoppdateringKafkaEvent.getFodselsnummer() `should be equal to` fodselsnummer
+            statusoppdateringKafkaEvent.getGrupperingsId() `should be equal to` grupperingsid
         }
     }
 


### PR DESCRIPTION
Nå skal alle eventtyper også sende inn `grupperingsid`. Da vil vi kunne teste `tidslinjen` med test-produsenten-vår og ønsket `grupperingsid`.