### PR TITLE
Tillater manglende verdi for link for Beskjeder.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/Beskjed.kt
@@ -13,7 +13,7 @@ data class Beskjed(
         override val sistOppdatert: ZonedDateTime,
         val synligFremTil: ZonedDateTime?,
         override val tekst: String,
-        override val link: String,
+        override val link: String?,
         override val aktiv: Boolean,
         val eksternVarsling: Boolean
 ) : Brukernotifikasjon {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducer.kt
@@ -35,12 +35,14 @@ class BeskjedProducer(private val beskjedKafkaProducer: KafkaProducerWrapper<Nok
         val build = BeskjedBuilder()
                 .withFodselsnummer(innloggetBruker.ident)
                 .withGrupperingsId(dto.grupperingsid)
-                .withLink(URL(dto.link))
                 .withTekst(dto.tekst)
                 .withTidspunkt(now)
                 .withSynligFremTil(weekFromNow)
                 .withSikkerhetsnivaa(innloggetBruker.innloggingsnivaa)
                 .withEksternVarsling(dto.eksternVarsling)
+        if(!dto.link.isNullOrBlank()) {
+            build.withLink(URL(dto.link))
+        }
         return build.build()
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/ProduceBeskjedDto.kt
@@ -2,7 +2,7 @@ package no.nav.personbruker.dittnav.eventtestproducer.beskjed
 
 
 class ProduceBeskjedDto(val tekst: String,
-                        val link: String,
+                        val link: String?,
                         val grupperingsid: String,
                         val eksternVarsling: Boolean = false) {
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/database/Brukernotifikasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventtestproducer/common/database/Brukernotifikasjon.kt
@@ -13,5 +13,5 @@ interface Brukernotifikasjon {
     val sistOppdatert: ZonedDateTime
     val aktiv: Boolean
     val tekst: String
-    val link: String
+    val link: String?
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventtestproducer/beskjed/BeskjedProducerTest.kt
@@ -8,6 +8,7 @@ import no.nav.personbruker.dittnav.common.util.kafka.producer.KafkaProducerWrapp
 import no.nav.personbruker.dittnav.eventtestproducer.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.eventtestproducer.common.createKeyForEvent
 import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be null`
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -33,6 +34,13 @@ class BeskjedProducerTest {
             beskjedKafkaEvent.getGrupperingsId() `should be equal to` grupperingsid
             beskjedKafkaEvent.getEksternVarsling() `should be equal to` true
         }
+    }
+
+    @Test
+    fun `should allow no link value`() {
+        val beskjedDto = ProduceBeskjedDto(tekst, null, grupperingsid, eksternVarsling)
+        val beskjedKafkaEvent = beskjedProducer.createBeskjedForIdent(innlogetBruker, beskjedDto)
+        beskjedKafkaEvent.getLink() `should be equal to` ""
     }
 
     @Test


### PR DESCRIPTION
Hvis link ikke var satt fra frontend feilet dette når vi skulle opprette en URL. Lagt til en sjekk som hindrer URL i å bli opprettet hvis link er tom.